### PR TITLE
Change strata to match other APR windows

### DIFF
--- a/APR-Core/CurrentStep.lua
+++ b/APR-Core/CurrentStep.lua
@@ -24,7 +24,7 @@ local isDragging = false
 -- Create the main current step frame
 local CurrentStepFrame = CreateFrame("Frame", "CurrentStepScreenPanel", UIParent, "BackdropTemplate")
 CurrentStepFrame:SetSize(FRAME_WIDTH, 50)
-CurrentStepFrame:SetFrameStrata("HIGH")
+CurrentStepFrame:SetFrameStrata("MEDIUM")
 CurrentStepFrame:SetClampedToScreen(true)
 CurrentStepFrame:SetBackdrop({
     bgFile = "Interface\\BUTTONS\\WHITE8X8",


### PR DESCRIPTION
I noticed that only the "current step" window had a strata higher than windows like the map, character inspect, and other default Blizzard frames. This change brings it in line with most of the other windows, including the "quest order list" window which I personally have next to the "current step" window and noticed that one covers the map and the other doesn't.