### PR TITLE
v4.9.2

### DIFF
--- a/APR-Core/ChangeLog.lua
+++ b/APR-Core/ChangeLog.lua
@@ -81,8 +81,8 @@ function APR.changelog:SetChangeLog()
         { "v4.9.2", "2025-03-09" },
         "#Bugs",
         "- Fixed taxi node retrieval method",
-        "- Fixed the mechanism to check if your route is up to date after an APR update for previous completed routes",
-        "- ",
+        "- Fixed the route update verification mechanism after an APR update for previously completed routes",
+        "- Implemented a way to reset a route before adding it to your custom path (useful for already completed routes)",
 
         { "v4.9.1", "2025-03-08" },
         "#Bugs",

--- a/APR-Core/ChangeLog.lua
+++ b/APR-Core/ChangeLog.lua
@@ -78,6 +78,11 @@ end
 
 function APR.changelog:SetChangeLog()
     local news = {
+        { "v4.10.0", "2025-03-09" },
+        "#Features",
+        "#Bugs",
+        "- Fixed taxi node retrieval method",
+
         { "v4.9.1", "2025-03-08" },
         "#Bugs",
         "- Fixed patch note display on reload when no route is loaded",

--- a/APR-Core/ChangeLog.lua
+++ b/APR-Core/ChangeLog.lua
@@ -78,10 +78,11 @@ end
 
 function APR.changelog:SetChangeLog()
     local news = {
-        { "v4.10.0", "2025-03-09" },
-        "#Features",
+        { "v4.9.2", "2025-03-09" },
         "#Bugs",
         "- Fixed taxi node retrieval method",
+        "- Fixed the mechanism to check if your route is up to date after an APR update for previous completed routes",
+        "- ",
 
         { "v4.9.1", "2025-03-08" },
         "#Bugs",

--- a/APR-Core/Commands.lua
+++ b/APR-Core/Commands.lua
@@ -10,12 +10,8 @@ function APR.command:SlashCmd(input)
         print(L["ADDON"] .. ' ' .. L["DISABLE"])
     end
     if (inputText == "reset" or inputText == "r") then
-        --Command for making the quest rescan on completion and reset, including previously skipped steps
-        APRData[APR.PlayerID][APR.ActiveRoute] = 1
-        APRData[APR.PlayerID][APR.ActiveRoute .. '-SkippedStep'] = 0
-        APR:GetTotalSteps(currentRoute)
-        APR.transport:GetMeToRightZone()
-        APR:PrintInfo(L["RESET_ROUTE"])
+        --Command to reset the current route
+        APR:ResetRoute(APR.ActiveRoute)
     elseif inputText == "resetcustom" then
         APRData.CustomRoute = {}
         C_UI.Reload()

--- a/APR-Core/Config_Route.lua
+++ b/APR-Core/Config_Route.lua
@@ -654,7 +654,7 @@ function APR.routeconfig:InitRouteConfig()
         end
 
         -- to trigger the frame
-        local routeZoneMapIDs, mapID, routeName, expansion = APR.transport:GetRouteMapIDsAndName()
+        local routeZoneMapIDs, mapID, routeName, expansion = APR.transport:GetCurrentRouteMapIDsAndName()
         APR.ActiveRoute = routeName
         APR:UpdateStep()
         APR.BookingList["UpdateMapId"] = true

--- a/APR-Core/Config_Route.lua
+++ b/APR-Core/Config_Route.lua
@@ -563,7 +563,7 @@ function SetRouteListTab(widget, name)
                 if IsRouteDisabled(name, route.routeName) then
                     GameTooltip:AddLine(L["ROUTE_DISABLED"], 1, 1, 1, true)
                 else
-                    GameTooltip:AddLine(L["MOVE_ZONE_TO_CUSTOM_PATH"], 1, 1, 1, true)
+                    GameTooltip:AddLine(L["MOVE_ROUTE_TO_CUSTOM_PATH"], 1, 1, 1, true)
                 end
                 GameTooltip:Show()
             end)
@@ -572,11 +572,14 @@ function SetRouteListTab(widget, name)
             end)
             lineContainer:SetScript("OnMouseDown", function(self, button)
                 if button == "RightButton" then
-                    -- Check is the route is up to date
-                    if APRData[APR.PlayerID][route.fileName] then
-                        APR:CheckRouteChanges(route.fileName)
+                    if IsShiftKeyDown() then
+                        APR:ResetRoute(route.fileName)
+                    else
+                        -- Check is the route is up to date
+                        if APRData[APR.PlayerID][route.fileName] then
+                            APR:CheckRouteChanges(route.fileName)
+                        end
                     end
-
                     tinsert(APRCustomPath[APR.PlayerID], route.routeName)
                     APR.routeconfig:SendMessage("APR_Custom_Path_Update")
                 end
@@ -654,7 +657,7 @@ function APR.routeconfig:InitRouteConfig()
         end
 
         -- to trigger the frame
-        local routeZoneMapIDs, mapID, routeName, expansion = APR.transport:GetCurrentRouteMapIDsAndName()
+        local routeZoneMapIDs, mapID, routeName, expansion = APR:GetCurrentRouteMapIDsAndName()
         APR.ActiveRoute = routeName
         APR:UpdateStep()
         APR.BookingList["UpdateMapId"] = true

--- a/APR-Core/Core.lua
+++ b/APR-Core/Core.lua
@@ -89,6 +89,7 @@ function APR:OnInitialize()
     APRScenarioMapIDCompleted = APRScenarioMapIDCompleted or {}
     APRScenarioCompleted = APRScenarioCompleted or {}
     APRItemLooted = APRItemLooted or {}
+
     APRTaxiNodes[APR.PlayerID] = APRTaxiNodes[APR.PlayerID] or {}
     APRCustomPath[APR.PlayerID] = APRCustomPath[APR.PlayerID] or {}
     APRZoneCompleted[APR.PlayerID] = APRZoneCompleted[APR.PlayerID] or {}

--- a/APR-Core/Transport.lua
+++ b/APR-Core/Transport.lua
@@ -12,7 +12,7 @@ function APR.transport:GetMeToRightZone()
         print("Function: APR.transport:GetMeToRightZone()")
     end
 
-    local routeZoneMapIDs, mapID, routeName, expansion = APR.transport:GetCurrentRouteMapIDsAndName()
+    local routeZoneMapIDs, mapID, routeName, expansion = APR:GetCurrentRouteMapIDsAndName()
     APR:CheckCurrentRouteUpToDate(routeName)
 
     if (routeZoneMapIDs and mapID and routeName) then
@@ -117,24 +117,6 @@ function APR.transport:GetMeToRightZone()
     end
 end
 
---- Get Route zone mapID and name
----@return Array<number> routeZoneMapIDs MapIDs list of the mapid for the route
----@return number mapID  the main mapid for the route
----@return string routeFileName Route File Name
----@return string expansion expansion name
-function APR.transport:GetCurrentRouteMapIDsAndName()
-    if (APR.settings.profile.debug) then
-        print("Function: APR.transport:GetRouteMapIDAndName()")
-    end
-
-    if not APRCustomPath or not APRCustomPath[APR.PlayerID] then
-        APR:PrintError('No APRCustomPath')
-        return nil, 0, '', ''
-    end
-    -- Get the current Route wanted MapIDs and Route File
-    local _, currentRouteName = next(APRCustomPath[APR.PlayerID])
-    return APR:GetRouteMapIDsAndName(currentRouteName)
-end
 
 --- Retrun the next MapIDs and worl position zone entry
 --- @param nextMapId number the wanted zone ID to reach

--- a/APR-Core/Transport.lua
+++ b/APR-Core/Transport.lua
@@ -376,8 +376,8 @@ APR.transport.eventFrame:SetScript("OnEvent", function(self, event, ...)
         --------------- Save FP ------------------
         ------------------------------------------
 
-        local playerMapID = APR:GetPlayerParentMapID()
-        local taxiNodes = C_TaxiMap.GetAllTaxiNodes(playerMapID)
+        local taxiMapID = GetTaxiMapID()
+        local taxiNodes = C_TaxiMap.GetAllTaxiNodes(taxiMapID)
 
         for _, node in ipairs(taxiNodes) do
             if node.state ~= Enum.FlightPathState.Unreachable and not APRTaxiNodes[APR.PlayerID][node.nodeID] then

--- a/APR-Core/Transport.lua
+++ b/APR-Core/Transport.lua
@@ -12,7 +12,7 @@ function APR.transport:GetMeToRightZone()
         print("Function: APR.transport:GetMeToRightZone()")
     end
 
-    local routeZoneMapIDs, mapID, routeName, expansion = APR.transport:GetRouteMapIDsAndName()
+    local routeZoneMapIDs, mapID, routeName, expansion = APR.transport:GetCurrentRouteMapIDsAndName()
     APR:CheckCurrentRouteUpToDate(routeName)
 
     if (routeZoneMapIDs and mapID and routeName) then
@@ -122,7 +122,7 @@ end
 ---@return number mapID  the main mapid for the route
 ---@return string routeFileName Route File Name
 ---@return string expansion expansion name
-function APR.transport:GetRouteMapIDsAndName()
+function APR.transport:GetCurrentRouteMapIDsAndName()
     if (APR.settings.profile.debug) then
         print("Function: APR.transport:GetRouteMapIDAndName()")
     end
@@ -133,16 +133,7 @@ function APR.transport:GetRouteMapIDsAndName()
     end
     -- Get the current Route wanted MapIDs and Route File
     local _, currentRouteName = next(APRCustomPath[APR.PlayerID])
-    for expansion, routeList in pairs(APR.RouteList) do
-        for routeFileName, routeName in pairs(routeList) do
-            if routeName == currentRouteName then
-                local mapID = string.match(routeFileName, "^(.-)-")
-                return APR.ZonesData.ExtensionRouteMaps[APR.Faction][expansion] or {}, tonumber(mapID, 10),
-                    routeFileName, expansion
-            end
-        end
-    end
-    return nil, 0, '', ''
+    return APR:GetRouteMapIDsAndName(currentRouteName)
 end
 
 --- Retrun the next MapIDs and worl position zone entry

--- a/APR-Core/helpers/StepHelper.lua
+++ b/APR-Core/helpers/StepHelper.lua
@@ -115,7 +115,7 @@ function APR:CheckIsInRouteZone()
     if not APR.ActiveRoute then
         return
     end
-    local routeZoneMapIDs, mapid, routeName, expansion = APR.transport:GetCurrentRouteMapIDsAndName()
+    local routeZoneMapIDs, mapid, routeName, expansion = APR:GetCurrentRouteMapIDsAndName()
     local parentContinentMapID = APR:GetPlayerParentMapID(Enum.UIMapType.Continent)
     local parenttMapID = APR:GetPlayerParentMapID()
     local currentMapID = C_Map.GetBestMapForUnit("player")
@@ -351,6 +351,25 @@ function APR:GetRouteMapIDsAndName(targetedRoute)
     return nil, 0, '', ''
 end
 
+--- Get Current Route zone mapID and name
+---@return Array<number> routeZoneMapIDs MapIDs list of the mapid for the route
+---@return number mapID  the main mapid for the route
+---@return string routeFileName Route File Name
+---@return string expansion expansion name
+function APR:GetCurrentRouteMapIDsAndName()
+    if (APR.settings.profile.debug) then
+        print("Function: APR.transport:GetRouteMapIDAndName()")
+    end
+
+    if not APRCustomPath or not APRCustomPath[APR.PlayerID] then
+        APR:PrintError('No APRCustomPath')
+        return nil, 0, '', ''
+    end
+    -- Get the current Route wanted MapIDs and Route File
+    local _, currentRouteName = next(APRCustomPath[APR.PlayerID])
+    return APR:GetRouteMapIDsAndName(currentRouteName)
+end
+
 function APR:CheckRouteChanges(route)
     local currentRoute = route or APR.ActiveRoute or ''
     local savedTotalSteps = APRData[APR.PlayerID][currentRoute .. '-TotalSteps']
@@ -390,6 +409,7 @@ end
 function APR:CheckCurrentRouteUpToDate(routeName)
     if APR.version ~= APR.settings.profile.lastRecordedVersion then
         -- //TODO :  To be removed in the next version (v4.10.0 or v5.0.0)
+        -- To remove Undermine route from the completed list if the preview Undermine route was completed
         if string.match(APR.settings.profile.lastRecordedVersion, "^v4%.[8-9]%.[0-9]+$") then
             for route, _ in pairs(APRZoneCompleted[APR.PlayerID]) do
                 if string.find(route, "Undermine") then

--- a/APR-Core/helpers/Utils.lua
+++ b/APR-Core/helpers/Utils.lua
@@ -193,3 +193,11 @@ function APR:titleCase(str)
         return first:upper() .. rest:lower()
     end))
 end
+
+function APR:ResetRoute(targetedRoute)
+    APRData[APR.PlayerID][targetedRoute] = 1
+    APRData[APR.PlayerID][targetedRoute .. '-SkippedStep'] = 0
+    APR:GetTotalSteps(targetedRoute)
+    APR.transport:GetMeToRightZone()
+    APR:PrintInfo(L["RESET_ROUTE"])
+end


### PR DESCRIPTION
- Fixed taxi node retrieval method.
- Fixed the route update verification mechanism after an APR update for previously completed routes.
- Implemented a way to reset a route before adding it to your custom path (useful for already completed routes).
