### PR TITLE
Fix Val'sharah route for DH quests

### DIFF
--- a/APR-Core/ChangeLog.lua
+++ b/APR-Core/ChangeLog.lua
@@ -94,6 +94,8 @@ function APR.changelog:SetChangeLog()
         { "v4.16.3", "2025-09-25" },
          "#Guides",
         "- Fixed missing Qpart for `Vengeance for the Stonedark` quest in Highmountain route (42373)",
+        "- Fixed some quest ID for Demon Hunter in Azsuna and Val'sharad route",
+        "- Fixed Shipwrecked Sailors quest for the Horde in Azsuna",
 
         { "v4.16.2", "2025-09-22" },
         "#Guides",

--- a/Routes/Legion/Legion.lua
+++ b/Routes/Legion/Legion.lua
@@ -1449,12 +1449,14 @@ APR.RouteQuestStepList["630-Azsuna"] = {
     },
     {
         PickUp = { 36920 },
+        PickUpDB = { 36920, 40815, 44140 },
         Coord = { x = 6961.7, y = -103.3 },
         Zone = 630,
         _index = 28,
     },
     {
         Done = { 36920 },
+        DoneDB = { 36920, 40815, 44140 },
         Coord = { x = 7113.6, y = -412.9 },
         Zone = 630,
         _index = 29,


### PR DESCRIPTION
Two quests (Brotherly Love and Illidari Freedom) have DH-specific versions. Adding PickupDB/QpartDB/DoneDB steps for these.