### PR TITLE
Temporary fix for broken The Dark Lady's Bidding gossip

### DIFF
--- a/Routes/Legion/Legion_Horde.lua
+++ b/Routes/Legion/Legion_Horde.lua
@@ -1289,13 +1289,14 @@ if APR.Faction == "Horde" then
         {
             PickUp = { 38872 },
             Coord = { x = 1552.5, y = 3192.5 },
+            GossipOptionID = 44644,
             _index = 169,
         },
         {
-            DropQuest = 38873,
+            Waypoint = 38872,
             Coord = { x = 1554, y = 3191.5 },
             ExtraLineText = "TALK_DREAD_RIDER_CULLEN",
-            Gossip = 38872,
+            GossipOptionID = 44644,
             _index = 170,
         },
         {


### PR DESCRIPTION
Previous route author attempted to use DropQuest step to select gossip when there is no qpart for this step. With recent code rewrites, this does not work. Edited to make the step a Waypoint with correct GossipOptionID until a proper step can be coded for this situation.