### PR TITLE
fix: correct arrow color gradient midpoint threshold (0.49 → 0.5)

### DIFF
--- a/APR-Core/Arrow.lua
+++ b/APR-Core/Arrow.lua
@@ -72,7 +72,7 @@ end
 local function GetArrowColor(percentage)
     if percentage > 0.98 then
         return 0, 1, 0
-    elseif percentage > 0.49 then
+    elseif percentage > 0.5 then
         return (1 - percentage) * 2, 1, 0
     end
     return 1, percentage * 2, 0


### PR DESCRIPTION
## Summary

The `GetArrowColor` function in `Arrow.lua` maps a facing-alignment percentage (0 = facing away, 1 = facing toward) to an RGB color gradient:

- **> 0.98** → green
- **0.49–0.98** → yellow-green blend: `((1-p)*2, 1, 0)`
- **0–0.49** → red-yellow blend: `(1, p*2, 0)`

The boundary between the two middle segments was set to `0.49` instead of the correct `0.5`. This causes a visible discontinuity in the green channel at that threshold:

| percentage | old result | new result |
|---|---|---|
| 0.489 | `(1, 0.978, 0)` | `(1, 0.978, 0)` |
| 0.491 | `(1.018→1, **1.0**, 0)` ← jump | `(1, 0.982, 0)` ← smooth |
| 0.500 | `(1, 1, 0)` | `(1, 1, 0)` |

At `0.5`, both gradient branches produce identical pure yellow `(1, 1, 0)`, so the transition is seamless. This is the mathematically correct midpoint for a symmetric red→yellow→green gradient.

## Change

`APR-Core/Arrow.lua` line 75: `0.49` → `0.5`